### PR TITLE
cycle tests in test selection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
 packages = find:
 install_requires=
     pytest>=7.1.2
-    iterfzf==1.0.0.42.0
+    iterfzf==1.0.0.44.0
 
 [options.entry_points]
 pytest11 =

--- a/src/pytest_fzf/main.py
+++ b/src/pytest_fzf/main.py
@@ -35,6 +35,7 @@ def pytest_collection_modifyitems(
         "prompt": "Select test(s): ",
         "preview": "tail -n +{2} {1}" + f"| {BAT_CMD}" if BAT_AVAILABLE else "",
         "query": query,
+        "cycle": True,
     }
 
     selected = iterfzf(


### PR DESCRIPTION
- add cycle flag to fzf
- bump iterfzf

tests can now be cycled: hitting down when selecting the first test will jump up to the beginning of the list and vice versa